### PR TITLE
[ feat ] board 목록 API 생성 

### DIFF
--- a/src/main/java/com/skmnservice/board/controller/BoardAPIController.java
+++ b/src/main/java/com/skmnservice/board/controller/BoardAPIController.java
@@ -2,16 +2,16 @@ package com.skmnservice.board.controller;
 
 import com.skmnservice.board.dto.BoardRequest;
 import com.skmnservice.board.dto.BoardResponse;
+import com.skmnservice.board.entity.Board;
 import com.skmnservice.board.service.BoardService;
 import com.skmnservice.global.response.ResponseCode;
 import com.skmnservice.global.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @Controller
@@ -24,6 +24,17 @@ public class BoardAPIController {
     public ResponseEntity<ResponseDto> write(@RequestBody BoardRequest requestDto){
         BoardResponse responseDto = boardService.write(requestDto);
         return ResponseEntity.ok(ResponseDto.of(ResponseCode.BOARD_SUCCESS, responseDto));
+    }
 
+    @GetMapping
+    public String boardList(@RequestParam(defaultValue = "0") int page,
+                            @RequestParam(defaultValue = "10") int size,
+                            @RequestParam(defaultValue = "") String keyword,
+                            Model model){
+        Page<Board> boardPage = boardService.getBoardList(page, size, keyword);
+        model.addAttribute("boardPage", boardPage);
+        model.addAttribute("currentPage", page);
+        model.addAttribute("keyword", keyword);
+        return "board/list";
     }
 }

--- a/src/main/java/com/skmnservice/board/controller/BoardAPIController.java
+++ b/src/main/java/com/skmnservice/board/controller/BoardAPIController.java
@@ -2,6 +2,7 @@ package com.skmnservice.board.controller;
 
 import com.skmnservice.board.dto.BoardRequest;
 import com.skmnservice.board.dto.BoardResponse;
+import com.skmnservice.board.service.BoardService;
 import com.skmnservice.global.response.ResponseCode;
 import com.skmnservice.global.response.ResponseDto;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/skmnservice/board/controller/BoardAPIController.java
+++ b/src/main/java/com/skmnservice/board/controller/BoardAPIController.java
@@ -1,0 +1,28 @@
+package com.skmnservice.board.controller;
+
+import com.skmnservice.board.dto.BoardRequest;
+import com.skmnservice.board.dto.BoardResponse;
+import com.skmnservice.global.response.ResponseCode;
+import com.skmnservice.global.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/api/board")
+public class BoardAPIController {
+    private final BoardService boardService;
+
+    @PostMapping("/write")
+    @ResponseBody
+    public ResponseEntity<ResponseDto> write(@RequestBody BoardRequest requestDto){
+        BoardResponse responseDto = boardService.write(requestDto);
+        return ResponseEntity.ok(ResponseDto.of(ResponseCode.BOARD_SUCCESS, responseDto));
+
+    }
+}

--- a/src/main/java/com/skmnservice/board/dto/BoardRequest.java
+++ b/src/main/java/com/skmnservice/board/dto/BoardRequest.java
@@ -1,0 +1,12 @@
+package com.skmnservice.board.dto;
+
+import java.util.UUID;
+
+public record BoardRequest(
+        String title,
+
+        UUID memberId,
+        String context,
+        boolean filePrecence
+) {
+}

--- a/src/main/java/com/skmnservice/board/dto/BoardResponse.java
+++ b/src/main/java/com/skmnservice/board/dto/BoardResponse.java
@@ -7,7 +7,6 @@ public record BoardResponse(
 
         String author,
         String context,
-        long hits,
         boolean filePrecence
 ) {
 }

--- a/src/main/java/com/skmnservice/board/dto/BoardResponse.java
+++ b/src/main/java/com/skmnservice/board/dto/BoardResponse.java
@@ -1,0 +1,13 @@
+package com.skmnservice.board.dto;
+
+import java.util.UUID;
+
+public record BoardResponse(
+        String title,
+
+        String author,
+        String context,
+        long hits,
+        boolean filePrecence
+) {
+}

--- a/src/main/java/com/skmnservice/board/entity/Board.java
+++ b/src/main/java/com/skmnservice/board/entity/Board.java
@@ -1,0 +1,45 @@
+package com.skmnservice.board.entity;
+
+import com.skmnservice.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Table(name = "member")
+@Getter
+@Setter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Board {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "board_id", nullable = false)
+    private UUID boardId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false) // 외래 키 설정
+    private Member author; // 작성자
+
+    @Column(name = "title", nullable = false, length = 50)
+    private String title;
+
+    @Column(name = "context", columnDefinition = "TEXT")
+    private String context;
+
+    @Column(name = "hits", nullable = false)
+    private long hits = 0;
+
+    @Column(name = "file_precence", nullable = false)
+    private boolean filePrecence;
+
+    @Column(name = "board_created_time", nullable = false)
+    private LocalDateTime boardCreatedTime;
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<File> files; // 첨부 파일 목록
+}

--- a/src/main/java/com/skmnservice/board/entity/File.java
+++ b/src/main/java/com/skmnservice/board/entity/File.java
@@ -1,0 +1,36 @@
+package com.skmnservice.board.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "file")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class File {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // IDENTITY로 Auto Increment
+    @Column(name = "file_id", nullable = false)
+    private Long fileId;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 게시글과 다대일 관계 설정
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board; // 첨부 파일이 속한 게시글
+
+    @Column(name = "original_name", nullable = false, length = 255)
+    private String originalName; // 원본 파일 이름
+
+    @Column(name = "save_name", nullable = false, length = 40)
+    private String saveName; // 서버에 저장된 파일 이름
+
+    @Column(name = "size", nullable = false)
+    private long size; // 파일 크기 (바이트)
+
+    @Column(name = "file_created_time", nullable = false)
+    private LocalDateTime fileCreatedTime; // 파일 업로드 시간
+}

--- a/src/main/java/com/skmnservice/board/repository/BoardRepository.java
+++ b/src/main/java/com/skmnservice/board/repository/BoardRepository.java
@@ -1,0 +1,12 @@
+package com.skmnservice.board.repository;
+
+import com.skmnservice.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface BoardRepository extends JpaRepository<Board, UUID> {
+    Page<Board> findByTitleOrAuthorId(String title, String authorId, Pageable pageable);
+}

--- a/src/main/java/com/skmnservice/board/service/BoardService.java
+++ b/src/main/java/com/skmnservice/board/service/BoardService.java
@@ -1,0 +1,43 @@
+package com.skmnservice.board.service;
+
+import com.skmnservice.board.dto.BoardRequest;
+import com.skmnservice.board.dto.BoardResponse;
+import com.skmnservice.board.entity.Board;
+import com.skmnservice.global.error.ErrorCode;
+import com.skmnservice.global.error.exception.NotFoundException;
+import com.skmnservice.member.entity.Member;
+import com.skmnservice.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class BoardService {
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public BoardResponse write(BoardRequest requestDto){
+        // 작성자 정보 조회
+        Member author = memberRepository.findById(requestDto.memberId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        // 게시글 생성
+        Board board = Board.builder()
+                .title(requestDto.title())
+                .context(requestDto.context())
+                .author(author)
+                .filePrecence(requestDto.filePrecence())
+                .boardCreatedTime(LocalDateTime.now())
+                .build();
+
+        // 게시글 저장
+        board = boardRepository.save(board);
+
+        // 응답 DTO 생성
+        return new BoardResponse(board.getTitle(), board.getContext(), author.getId(), board.getFiles().isEmpty());
+    }
+}

--- a/src/main/java/com/skmnservice/board/service/BoardService.java
+++ b/src/main/java/com/skmnservice/board/service/BoardService.java
@@ -3,6 +3,7 @@ package com.skmnservice.board.service;
 import com.skmnservice.board.dto.BoardRequest;
 import com.skmnservice.board.dto.BoardResponse;
 import com.skmnservice.board.entity.Board;
+import com.skmnservice.board.repository.BoardRepository;
 import com.skmnservice.global.error.ErrorCode;
 import com.skmnservice.global.error.exception.NotFoundException;
 import com.skmnservice.member.entity.Member;

--- a/src/main/java/com/skmnservice/board/service/BoardService.java
+++ b/src/main/java/com/skmnservice/board/service/BoardService.java
@@ -10,6 +10,9 @@ import com.skmnservice.member.entity.Member;
 import com.skmnservice.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -41,4 +44,11 @@ public class BoardService {
         // 응답 DTO 생성
         return new BoardResponse(board.getTitle(), board.getContext(), author.getId(), board.getFiles().isEmpty());
     }
+
+    @Transactional
+    public Page<Board> getBoardList(int page, int size, String keyword){
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return boardRepository.findByTitleOrAuthorId(keyword, keyword, pageable);
+    }
+
 }

--- a/src/main/java/com/skmnservice/global/response/ResponseCode.java
+++ b/src/main/java/com/skmnservice/global/response/ResponseCode.java
@@ -15,6 +15,10 @@ public enum ResponseCode {
     // User
     LOGIN_SUCCESS(200, "U001", "로그인에 성공하였습니다."),
     LOGIN_FAIL(200, "U004", "로그인에 실패하였습니다."),
+
+    // Board
+    BOARD_SUCCESS(200, "B001", "게시판 작성에 성공하였습니다."),
+    BOARD_FAIL(200, "B002", "게시판 작성에 실패하였습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/skmnservice/member/config/WebSecurityConfig.java
+++ b/src/main/java/com/skmnservice/member/config/WebSecurityConfig.java
@@ -24,9 +24,10 @@ public class WebSecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/member/login", "/board").permitAll()
+                        .requestMatchers("/api/member/login", "/board", "/h2-console/**").permitAll()
                         .requestMatchers("/css/**", "/js/**", "/images/**").permitAll()
                         .anyRequest().authenticated())
+                .headers(headers -> headers.frameOptions().disable())
                 .formLogin(form -> form
                         .loginPage("/api/member/login") // 로그인 페이지 경로
                         .defaultSuccessUrl("/main")) // 로그인 완료 이후 이동할 경로

--- a/src/main/java/com/skmnservice/member/entity/Member.java
+++ b/src/main/java/com/skmnservice/member/entity/Member.java
@@ -1,11 +1,13 @@
 package com.skmnservice.member.entity;
 
+import com.skmnservice.board.entity.Board;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -27,8 +29,14 @@ public class Member implements UserDetails { // UserDetails를 상속 받아 인
     @Column(name = "password", length = 200)
     private String password;
 
+    @Column(name = "reg_time")
+    private LocalDateTime regTime;
+
     @Column(name = "name", length = 50)
     private String name;
+
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Board> boards; // 회원이 작성한 게시글 목록
 
     @Builder
     public Member(UUID memberId, String id, String password, String name){


### PR DESCRIPTION
## Issue
- #5 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/board -> dev

## 변경 사항
- 게시판 목록을 사용할 수 있는 기능입니다.
     - 로그인을 하지 않아도 리스트를 확인할 수 있습니다.
     - 작성 제목과 작성자로 검색할 수 있습니다.
     - 한 페이지당 게시물 10개씩 리스트를 볼 수 있습니다.
     - 게시물 관련하여 제목, 작성자 ID, 조회수, 첨부파일 여부, 등록일 등을 볼 수 있으며 등록일 기준으로 역순으로 확인이 가능합니다.